### PR TITLE
fixed thruk logrotate.conf permissions to match skel.permissions

### DIFF
--- a/packages/thruk/skel/etc/logrotate.d/thruk
+++ b/packages/thruk/skel/etc/logrotate.d/thruk
@@ -4,5 +4,5 @@
 	compress
 	delaycompress
 	notifempty
-	create 640 ###SITE### ###SITE### 
+	create 660 ###SITE### ###SITE### 
 }


### PR DESCRIPTION
Hi there,

Find attached the change to fix thruk's logrotate.conf. Thruk stopped working after the first logrotate because of the wrong permissions.


Cheers,
Pfuender