### PR TITLE
set 0.0.0.0 explicitly for pnp_gearman_worker init script

### DIFF
--- a/packages/pnp4nagios/skel/etc/init.d/pnp_gearman_worker
+++ b/packages/pnp4nagios/skel/etc/init.d/pnp_gearman_worker
@@ -24,7 +24,12 @@ fi
 ### read mod_gearman port.conf ###
 if [ -r etc/mod-gearman/port.conf ] ; then
     . etc/mod-gearman/port.conf
-    GM_PORT="--gearman=$server"
+    PORT=`echo $server | awk -F: {'print $2'}`
+    LISTEN=`echo $server | awk -F: {'print $1'}`
+    if [ -z "$LISTEN" ]; then
+        LISTEN=0.0.0.0
+    fi
+    GM_PORT="--gearman=$LISTEN:$PORT"
 else
     GM_PORT="--gearman"
 fi


### PR DESCRIPTION
When only a port is given, e.g. ":4730" for example via "omd config", set ip address explicitly to "0.0.0.0" in pnp_gearman_worker init script. At least SLES11 had issues without it.