### PR TITLE
Fix Naemon-Livestatus for MK_MultiSite

### DIFF
--- a/packages/naemon-livestatus/patches/0001-Send-null-Response-when-Livestatus-Column-doesn-t-ex.patch
+++ b/packages/naemon-livestatus/patches/0001-Send-null-Response-when-Livestatus-Column-doesn-t-ex.patch
@@ -1,0 +1,26 @@
+From 45863cdd1080d4fa08287c4e3cae699756eb6600 Mon Sep 17 00:00:00 2001
+From: root <root@checkmk.main.htl-perg.at>
+Date: Thu, 30 Mar 2017 18:33:35 +0200
+Subject: [PATCH 1/1] Send null Response when Livestatus Column doesn't exist
+
+---
+ src/Query.cc | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/Query.cc b/src/Query.cc
+index f53fd28..3c331ca 100644
+--- a/src/Query.cc
++++ b/src/Query.cc
+@@ -573,8 +573,7 @@ void Query::parseColumnsLine(char *line)
+         if (column)
+             _columns.push_back(column);
+         else {
+-            _output->setError(RESPONSE_CODE_INVALID_HEADER,
+-                   "Table '%s' has no column '%s'", _table->name(), column_name);
++            logger(LOG_WARNING, "Replacing non-existing column '%s' with null column", column_name);
+             Column *col = createDummyColumn(column_name);
+             _columns.push_back(col);
+         }
+-- 
+2.7.4
+

--- a/packages/naemon-livestatus/patches/0001-Send-null-Response-when-Livestatus-Column-doesn-t-ex.patch
+++ b/packages/naemon-livestatus/patches/0001-Send-null-Response-when-Livestatus-Column-doesn-t-ex.patch
@@ -1,26 +1,26 @@
-From 45863cdd1080d4fa08287c4e3cae699756eb6600 Mon Sep 17 00:00:00 2001
-From: root <root@checkmk.main.htl-perg.at>
-Date: Thu, 30 Mar 2017 18:33:35 +0200
-Subject: [PATCH 1/1] Send null Response when Livestatus Column doesn't exist
+From f20293ad44561dfe14bb2d3daaf4f04eb3c8dd23 Mon Sep 17 00:00:00 2001
+From: Firegore <firegore@users.noreply.github.com>
+Date: Fri, 31 Mar 2017 17:54:57 +0200
+Subject: [PATCH 1/1] Fix MK_Multisite unkown Column error
 
 ---
  src/Query.cc | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/src/Query.cc b/src/Query.cc
-index f53fd28..3c331ca 100644
+index f53fd28..cb0187e 100644
 --- a/src/Query.cc
 +++ b/src/Query.cc
-@@ -573,8 +573,7 @@ void Query::parseColumnsLine(char *line)
-         if (column)
-             _columns.push_back(column);
-         else {
+@@ -530,8 +530,7 @@ void Query::parseSortLine(char *line)
+     if( column_name != 0 ) {
+         Column *column = _table->column(column_name);
+         if (column == 0) {
 -            _output->setError(RESPONSE_CODE_INVALID_HEADER,
 -                   "Table '%s' has no column '%s'", _table->name(), column_name);
-+            logger(LOG_WARNING, "Replacing non-existing column '%s' with null column", column_name);
-             Column *col = createDummyColumn(column_name);
-             _columns.push_back(col);
++            logger(LOG_DEBUG, "Replacing non-existing column '%s' with null column", column_name);
+             column = createDummyColumn(column_name);
          }
+ 
 -- 
 2.7.4
 


### PR DESCRIPTION
Make Livestatus return a null response instead of an Error when the requested Column doesnt exist.
Otherwise MK_Multisite throws Error on the Problem Views

Fixes #18 
The Patch is taken from [Naemon-Livestatus PR#15](https://github.com/naemon/naemon-livestatus/pull/15)

Tested on Ubuntu 16.04