### PR TITLE
copytruncate for InfluxDB logrotation

### DIFF
--- a/packages/influxdb/skel/etc/logrotate.d/influxdb
+++ b/packages/influxdb/skel/etc/logrotate.d/influxdb
@@ -3,9 +3,6 @@
 	rotate 52
 	compress
 	delaycompress
-	notifempty
 	create 640 ###SITE### ###SITE###
-	postrotate
-		###ROOT###/bin/omd reload influxdb > /dev/null
-	endscript
+	copytruncate
 }


### PR DESCRIPTION
InfluxDB seems to need copytruncate for proper logfile rotation (see https://github.com/influxdata/influxdb/issues/4635). Else it still writes to the old logfile.