### PR TITLE
Quote the rrd-filenames in backtick-commands

### DIFF
--- a/packages/nagflux/migrate_pnp_to_nagflux
+++ b/packages/nagflux/migrate_pnp_to_nagflux
@@ -138,8 +138,8 @@ for my $xml_file (@xml_files) {
                 }
             }
         }
-        `rrdtool flushcached --daemon unix:tmp/run/rrdcached.sock $rrd_file >/dev/null 2>&1`;
-        my $raw = `rrdtool dump $rrd_file`;
+        `rrdtool flushcached --daemon unix:tmp/run/rrdcached.sock '$rrd_file' >/dev/null 2>&1`;
+        my $raw = `rrdtool dump '$rrd_file'`;
         my $parser = XML::LibXML->new();
         my $doc = XML::LibXML->load_xml(string => $raw, load_ext_dtd => 0);
         # import in reverse order, otherwise values from fine granular rrds would be overwritten from large ones


### PR DESCRIPTION
The migration failed for rrd-files which contained eg. brackets in the filename. Quoting those does the job, and I can import them all again.

Happy merging! ;-)