### PR TITLE
limits and specially TasksMax information

### DIFF
--- a/packages/omd/omd.service
+++ b/packages/omd/omd.service
@@ -11,5 +11,14 @@ ExecReload=/usr/bin/omd reload
 RemainAfterExit=yes
 Restart=no
 
+# Not limited by systemd as default
+LimitCORE=infinity
+LimitNOFILE=infinity
+LimitNPROC=infinity
+
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this property. (SLES 12 SP3)
+#TasksMax=infinity
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
TasksMax on systemd 226 and above probally will have a default of 512 tasks.