### PR TITLE
Fixed dependency on CentOS 8 #92

### DIFF
--- a/distros/Makefile.CENTOS_8
+++ b/distros/Makefile.CENTOS_8
@@ -93,6 +93,7 @@ OS_PACKAGES          += patch
 OS_PACKAGES          += perl-IO-Socket-SSL
 OS_PACKAGES          += perl-IO-Zlib
 OS_PACKAGES          += perl-Locale-Maketext-Simple
+OS_PACKAGES          += perl-Module-Load
 OS_PACKAGES          += php
 OS_PACKAGES          += php-cli
 OS_PACKAGES          += php-gd


### PR DESCRIPTION
This solves the dependency problem described in https://github.com/ConSol/omd/issues/92#issue-536631228

I don't have a building environment, but I checked twice the module is spelled correctly.