### PR TITLE
omd: fix use of -r on groupadd

### DIFF
--- a/packages/omd/omd
+++ b/packages/omd/omd
@@ -381,7 +381,9 @@ def groupdel(groupname):
 def groupadd(groupname, gid = None):
     cmd = "groupadd "
     if gid != None:
-        cmd += "-r -g %d " % int(gid)
+        cmd += "-g %d " % int(gid)
+    else:
+        cmd += "-r "
     cmd += groupname
 
     if 0 != os.system(cmd):


### PR DESCRIPTION
create system group without given GID, instead of being useless option if GID is already provided