### PR TITLE
rrdcached: add daemon reload after rotation to avoid use of still open but deleted files

### DIFF
--- a/packages/rrdtool/skel/etc/logrotate.d/rrdcached
+++ b/packages/rrdtool/skel/etc/logrotate.d/rrdcached
@@ -4,4 +4,7 @@
         compress
         delaycompress
         create 640 ###SITE### ###SITE### 
+        postrotate
+                ###ROOT###/etc/init.d/rrdcached reload
+        endscript
 }


### PR DESCRIPTION
found today in my open but deleted file checker:

```
rrdcached 1871482                            SITE1    3w      REG                8,2       2816     0   12585357 /opt/omd/sites/SITE1/var/log/rrdcached.log.1 (deleted)
```

OMD's logrotate was executed, but the config for `rrdcached` misses postrotate action