### PR TITLE
Fix for #155

### DIFF
--- a/packages/pnp4nagios/patches/206-fix-155.patch
+++ b/packages/pnp4nagios/patches/206-fix-155.patch
@@ -1,0 +1,31 @@
+--- a/scripts/process_perfdata.pl.in	2023-02-20 11:06:45.000000000 +0000
++++ b/scripts/process_perfdata.pl.in	09:00:52.329168164 +0000
+@@ -101,7 +101,16 @@
+ parse_config($opt_c);
+ $conf{'GLOBAL_RRD_STORAGE_TYPE'} = uc($conf{'RRD_STORAGE_TYPE'}); # store the initial value for later use
+
+-my %stats = init_stats();
++my %stats = (
++    timet       => 0,
++    error       => 0,
++    invalid     => 0,
++    skipped     => 0,
++    runtime     => 0,
++    rows        => 0,
++    create      => 0,
++    update      => 0,
++);
+ my $cypher;
+
+ #
+@@ -187,7 +196,9 @@
+         $stats{runtime} += $rt;
+         $stats{rows}++;
+         if( ( int $stats{timet} / 60 ) < ( int time / 60 )){
+-            store_internals();
++            if($stats{timet} > 0) {
++                store_internals();
++            }
+             init_stats();
+         }
+         print_log( "Gearman job end (runtime ${rt}s) ...", 1 );


### PR DESCRIPTION
Previously the value of `$stats{timet}` would be initialised based on the last time that `omd restart pnp_gearman_worker` was executed, this means that the longer that OMD runs, each new instance of the worker that's created starts off with a "broken" snapshot of their stats. By initialising it to 0 and skipping that save, we throw away the first-time stats (which are empty anyway) and then save from then onward.

NB I think the format of this patch is correct, however I don't have a build environment for the whole of OMD built so I've had to guess it a little.