### PR TITLE
repaired victoriametrics backup scripts

### DIFF
--- a/packages/victoriametrics/vmbackup-cleanup-cron
+++ b/packages/victoriametrics/vmbackup-cleanup-cron
@@ -2,13 +2,18 @@
 
 LOG_DIR=${OMD_ROOT}/var/victoriametrics
 DATA_PATH=${OMD_ROOT}/var/victoriametrics/data
+CONF_DIR=$OMD_ROOT/etc/victoriametrics/conf.d
 
 mkdir -p $LOG_DIR
 
 (
-. ${OMD_ROOT}/etc/victoriametrics/victoriametrics.conf
 
-if [ $? != 0 ] ; then
+for CFG in ${CONF_DIR}/*.conf; do
+  . ${CFG}
+done
+. etc/victoriametrics/backup.conf
+
+if [ -z "$vm_loggerLevel" ] ; then
   echo "source of config failed"
   exit 8
 fi

--- a/packages/victoriametrics/vmbackup-cleanup-cron
+++ b/packages/victoriametrics/vmbackup-cleanup-cron
@@ -54,8 +54,8 @@ fi
 echo ">> retention at $( date +%Y-%m-%d-%H) "
 
 RC=0
-LL=$(echo -n $SNAPSHOT_OUT | jsonpath.py '$.snapshots[*]')
-for SNAPSHOT_NAME in $(echo -n $SNAPSHOT_OUT | jsonpath.py '$.snapshots[*]')
+
+for SNAPSHOT_NAME in $(echo -n $SNAPSHOT_OUT | grep -oP '"snapshots": *\[\K[^]]+' | tr -d ' "' | tr ',' ' ')
 do
   echo "snapshots: ${SNAPSHOT_NAME}"
   #du -ch -d1 $storageDataPath/snapshots/${SNAPSHOT_NAME}

--- a/packages/victoriametrics/vmbackup-cron
+++ b/packages/victoriametrics/vmbackup-cron
@@ -2,14 +2,18 @@
 
 LOG_DIR=${OMD_ROOT}/var/victoriametrics
 DATA_PATH=${OMD_ROOT}/var/victoriametrics/data
+CONF_DIR=$OMD_ROOT/etc/victoriametrics/conf.d
 
 mkdir -p $LOG_DIR
 
 (
 
-. ${OMD_ROOT}/etc/victoriametrics/victoriametrics.conf
+for CFG in ${CONF_DIR}/*.conf; do
+  . ${CFG}
+done
+. etc/victoriametrics/backup.conf
 
-if [ $? != 0 ] ; then
+if [ -z "$vm_loggerLevel" ] ; then
   echo "source of config failed"
   exit 8
 fi

--- a/packages/victoriametrics/vmbackup-cron
+++ b/packages/victoriametrics/vmbackup-cron
@@ -74,7 +74,7 @@ fi
 
 echo $SNAPSHOT_OUT
 
-SNAPSHOT_NAME=$(echo -n $SNAPSHOT_OUT | jsonpath.py '$.snapshot')
+SNAPSHOT_NAME=$(echo -n $SNAPSHOT_OUT | grep -oP '"snapshot": *"\K[^"]+')
 
 if [ "${SNAPSHOT_NAME}" = "" ] ; then
   echo "snapshot failed"


### PR DESCRIPTION
The files "vmbackup-cron" and "vmbackup-cleanup-cron" uses the old config path to "victoriametrics.conf" which has been replaced by dynamic files in the "config.d" folder. 
The jsonpath.py script did also not work for me, so I replaced it with simple grep and tr calls. 